### PR TITLE
fix: change source and version in podspec

### DIFF
--- a/RxBluetoothKit.podspec
+++ b/RxBluetoothKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "RxBluetoothKit"
-  s.version          = "7.0.0"
+  s.version          = "7.0.2"
   s.summary          = "Bluetooth library for RxSwift"
 
   s.description      = <<-DESC
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.homepage         = "https://github.com/polidea/RxBluetoothKit"
   s.license          = 'Apache License, Version 2.0.'
   s.author           = { "Przemysław Lenart" => "przemek.lenart@polidea.com", "Kacper Harasim" => "kacper.harasim@polidea.com", "Michał Laskowski" => "michal.laskowski@polidea.com", "Paweł Janeczek" => "pawel.janeczek@polidea.com", "Bartosz Stelmaszuk" => "bartosz.stelmaszuk@polidea.com" }
-  s.source           = { :git => "https://github.com/polidea/RxBluetoothKit.git", :tag => s.version.to_s }
+  s.source           = { :git => "https://github.com/i-mobility/RxBluetoothKit", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/polidea'
 
   s.ios.deployment_target = '9.0'


### PR DESCRIPTION
I used the polidea version of RxBluettohKit in one of my private pods.
When they stopped maintaining it, I switch to your fork to be able to use RxSwift 6.0 and a compatible version with iOS15.
Thanks for the work, it helped us a lot !

Until now, I used your version this way :
- in the podspec of my private pod depending on RxBluetoothKit, I just put a `s.dependency = 'RxBluetoothKit`
- in the podfile of the app using my pod, I add the two following lines :
```
pod 'MyPod', :git => 'git@github.com:myaccount/mypod.git', :tag => 'X.Y.Z'
  pod 'RxBluetoothKit', :git => 'git@github.com:i-mobility/RxBluetoothKit.git', :tag => '7.0.2'
```

That works, but that forces me to sync all version dependencies directly in my final Pofile.

To prevent that, I would like to add my pod to a private repo, and for that, I need also add your pod to the sema repo.
That would allow me to handle all dependency versions directly in `.podspec` files.

But to do that, the podspec in your repo should point to the last tag, with the iOS15 fixes.

That's why I make this pull request.

PS : I always have the ability to use a fork of your repo where I would make the changes, but I think that could be great to have only one fork (yours ;) ) where the podspec is up-to-date with the repo versioning